### PR TITLE
fix: erigon container config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ run `sudo mkdir -p` to create those directories
 
 Launch [Erigon](https://github.com/ledgerwatch/erigon) and [Prysm](https://github.com/prysmaticlabs/prysm) to provide L1 RPC of Testnet [Sepolia](https://sepolia.etherscan.io/).
 
+## System requirements
+
+The Sepolia node has been tested on: 8 GB Memory / 2 Intel vCPUs / 160 GB Disk + 1000 GB / SGP1 - Debian 12 x64 (DigitalOcean)
+
 ## Generate JWT token
 
 The HTTP connection between the beacon node and execution node needs to be authenticated using a JWT token. Refer to the Prysm [authentication](https://docs.prylabs.network/docs/execution-node/authentication) for more details.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ openssl rand -hex 32 | tr -d "\n" > "jwt.hex"
 
 ## Set up permission
 
-Run the following command to avoid permission issue like [this](https://github.com/ledgerwatch/erigon/issues/3950)
+Run the following command to avoid permission issues like
+- https://github.com/ledgerwatch/erigon/issues/3950
+- https://github.com/erigontech/erigon/issues/12931
+
 ```
-sudo chown 1000:1000 <ERIGON_DATA_DIR>
+sudo chown 100:1000 <ERIGON_DATA_DIR>
 ```
 
 ## Launch L1 node

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 ```
 git clone https://github.com/Snapchain/node-launch.git
-cd node-launch
+cd node-launch/sepolia
+cp .env.example .env
 ```
+
+then set `ERIGON_DATA_DIR` and `PRYSM_DATA_DIR` to the locations inside the mounted volume
+
+run `sudo mkdir -p` to create those directories
 
 ## Overview
 
@@ -16,7 +21,6 @@ The HTTP connection between the beacon node and execution node needs to be authe
 Use OpenSSL to create the token via command:
 
 ```
-cd sepolia
 openssl rand -hex 32 | tr -d "\n" > "jwt.hex"
 ```
 

--- a/sepolia/.env.example
+++ b/sepolia/.env.example
@@ -1,2 +1,2 @@
-ERIGON_DATA_DIR=/path/to/erigon/data
-PRYSM_DATA_DIR=/path/to/prysm/data
+ERIGON_DATA_DIR=/mnt/volume_sgp1_01/erigon/data
+PRYSM_DATA_DIR=/mnt/volume_sgp1_01/prysm/data

--- a/sepolia/docker-compose.yml
+++ b/sepolia/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   erigon:
     image: erigontech/erigon:v2.60.10
-    user: "1000:1000"
+    user: "100:1000"
     container_name: erigon-sepolia
     command: |
       --chain=sepolia --prune=hrtc

--- a/sepolia/docker-compose.yml
+++ b/sepolia/docker-compose.yml
@@ -1,11 +1,12 @@
 services:
 
   erigon:
-    image: thorax/erigon:2.60.8
+    image: erigontech/erigon:v2.60.10
     user: "1000:1000"
     container_name: erigon-sepolia
     command: |
-      --chain=sepolia --prune=htc
+      --chain=sepolia --prune=hrtc
+      --torrent.download.rate=512mb
       --authrpc.addr="erigon" --authrpc.jwtsecret=/jwt.hex --authrpc.vhosts="erigon"
       --http.api="eth,debug,net,engine,web3" --http.addr="0.0.0.0" --http.corsdomain="*" --http.vhosts='*'
       --ws


### PR DESCRIPTION
## Summary

- add complete instructions to README
- `thorax/erigon` no longer exists (https://github.com/erigontech/erigon/releases/tag/2.60.7)
- "To increase download speed add --torrent.download.rate=512mb (default is 16mb)" ([ref](https://erigon.gitbook.io/erigon/eli5-nodes/how-to-run-an-ethereum-node#configure-erigon-client))
- replace `htc` to `hrtc` (https://erigon.gitbook.io/erigon/advanced-usage/options)
- fix permission issue `user: "100:1000"` (reported here: https://github.com/erigontech/erigon/issues/12931)

## Test Plan

`docker compose up -d`

then run `docker logs erigon-sepolia -f -n 100`

```
[INFO] [11-30|13:23:34.140] [1/12 Snapshots] download                progress="0.71% 1.7GB/241.7GB" time-left=5hrs:20m total-time=2m20s download=12.8MB/s upload=0B/s peers=10 files=93 metadata=93/93 connections=29 alloc=176.3MB sys=288.4MB
[INFO] [11-30|13:23:53.749] [snapshots] no progress yet              files=72 list=v1-004300-004400-headers.seg,v1-004500-004600-headers.seg,v1-005300-005400-transactions.seg,v1-005500-005600-transactions.seg,v1-005600-005700-bodies.seg,...
[INFO] [11-30|13:23:54.139] [1/12 Snapshots] download                progress="0.78% 1.9GB/241.7GB" time-left=7hrs:40m total-time=2m40s download=8.9MB/s upload=0B/s peers=11 files=93 metadata=93/93 connections=38 alloc=121.9MB sys=288.4MB
[INFO] [11-30|13:24:13.728] [p2p] GoodPeers                          eth67=1
[INFO] [11-30|13:24:13.743] [mem] memory stats                       Rss=2.4GB Size=0B Pss=2.4GB SharedClean=4.0KB SharedDirty=0B PrivateClean=2.1GB PrivateDirty=294.6MB Referenced=2.4GB Anonymous=291.3MB Swap=0B alloc=151.7MB sys=288.4MB
[INFO] [11-30|13:24:13.744] [snapshots] no progress yet              files=72 list=v1-004800-004900-transactions.seg,v1-005000-005100-bodies.seg,v1-005100-005200-transactions.seg,v1-005400-005500-transactions.seg,v1-005800-005900-bodies.seg,...
[INFO] [11-30|13:24:13.744] [txpool] stat                            pending=0 baseFee=0 queued=0 alloc=151.8MB sys=288.4MB
[INFO] [11-30|13:24:14.140] [1/12 Snapshots] download                progress="0.86% 2.1GB/241.7GB" time-left=6hrs:38m total-time=3m0s download=10.3MB/s upload=0B/s peers=13 files=93 metadata=93/93 connections=43 alloc=164.6MB sys=288.4MB
[INFO] [11-30|13:24:33.739] [snapshots] no progress yet              files=71 list=v1-004500-004600-transactions.seg,v1-004800-004900-transactions.seg,v1-005000-005100-bodies.seg,v1-005100-005200-transactions.seg,v1-005400-005500-transactions.seg,...
[INFO] [11-30|13:24:34.139] [1/12 Snapshots] download                progress="0.94% 2.3GB/241.7GB" time-left=7hrs:14m total-time=3m20s download=9.4MB/s upload=0B/s peers=13 files=93 metadata=93/93 connections=44 alloc=158.9MB sys=300.4MB
```